### PR TITLE
Fixed WordCompleter import

### DIFF
--- a/RiskIQ.Sunburst.Hunter.py
+++ b/RiskIQ.Sunburst.Hunter.py
@@ -11,7 +11,7 @@ import os
 import time
 import sys
 from prompt_toolkit import prompt
-from prompt_toolkit.contrib.completers import WordCompleter
+from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.styles import Style
 
 class style():


### PR DESCRIPTION
```
python RiskIQ.Sunburst.Hunter.py
Traceback (most recent call last):
  File "RiskIQ.Sunburst.Hunter.py", line 14, in <module>
    from prompt_toolkit.contrib.completers import WordCompleter
ImportError: cannot import name 'WordCompleter' from 'prompt_toolkit.contrib.completers'
```