### PR TITLE
http > https

### DIFF
--- a/whitelists/whitelist.txt
+++ b/whitelists/whitelist.txt
@@ -1,3 +1,3 @@
 riskiq.com
-http://www.riskiq.com/
+https://www.riskiq.com/
 0.0.0.0


### PR DESCRIPTION
In the file `whitelists/whitelist.txt`, RiskIQ web was pointing to `http://`. Now it points to `https://`